### PR TITLE
Require all invoice fields in schema

### DIFF
--- a/ai_invoice_extract.py
+++ b/ai_invoice_extract.py
@@ -81,7 +81,21 @@ INVOICE_SCHEMA = {
             "currency":           {"type": "string", "enum": ["EUR"], "default": "EUR"},
             "source_file":        {"type": "string"}
         },
-        "required": ["invoice_number", "total_eur", "source_file"],
+        "required": [
+            "supplier",
+            "supplier_vat",
+            "invoice_number",
+            "invoice_date_start",
+            "invoice_date_end",
+            "billing_id",
+            "domain",
+            "subtotal_eur",
+            "vat_percent",
+            "vat_amount_eur",
+            "total_eur",
+            "currency",
+            "source_file",
+        ],
         "additionalProperties": False
     },
     "strict": True


### PR DESCRIPTION
## Summary
- Make all schema properties required so invoices always include every field

## Testing
- `OPENAI_API_KEY=dummy python ai_invoice_extract.py -i dummy.pdf -o out.csv` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68a606b9d300832dad2928dab775f6ff