### PR TITLE
Use OPENAI_API_KEY_PARSER environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ python3 -m venv venv
 source venv/bin/activate   # Windows: venv\Scripts\activate
 pip install -r requirements.txt
 
-cp .env.example .env       # add your OpenAI API key
+cp .env.example .env       # add your OpenAI API key as OPENAI_API_KEY_PARSER
 python ai_invoice_extract.py -i "invoices/*.pdf" -o output/invoices.csv
 
 ```
+
+Ensure your OpenAI API key is available via the `OPENAI_API_KEY_PARSER` environment variable (the script also falls back to `OPENAI_API_KEY`).
 
 
 ##  Related Blog Post

--- a/ai_invoice_extract.py
+++ b/ai_invoice_extract.py
@@ -48,11 +48,14 @@ def normalize(txt: str) -> str:
 #  OpenAI client + schema
 # =========================
 load_dotenv()
-API_KEY = os.getenv("OPENAI_API_KEY")
+# Prefer the dedicated parser key but allow the old name as a fallback
+API_KEY = os.getenv("OPENAI_API_KEY_PARSER") or os.getenv("OPENAI_API_KEY")
 MODEL   = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
 if not API_KEY:
-    raise RuntimeError("OPENAI_API_KEY ontbreekt. Zet hem in .env of in je omgeving.")
+    raise RuntimeError(
+        "OPENAI_API_KEY_PARSER ontbreekt. Zet OPENAI_API_KEY_PARSER (of OPENAI_API_KEY) in .env of in je omgeving."
+    )
 
 client = OpenAI(api_key=API_KEY)
 


### PR DESCRIPTION
## Summary
- Look for API key in `OPENAI_API_KEY_PARSER` with fallback to `OPENAI_API_KEY`
- Document new `OPENAI_API_KEY_PARSER` variable in the README

## Testing
- `pytest -q`
- `python -m py_compile ai_invoice_extract.py parse_invoices.py`


------
https://chatgpt.com/codex/tasks/task_e_68a607ceb078832d89baedb5ad1c2680