### PR TITLE
Parse domain from Bill to block

### DIFF
--- a/parse_invoices.py
+++ b/parse_invoices.py
@@ -22,12 +22,9 @@ PATTERNS = {
     "invoice_date": re.compile(
         r"Summary\s+for\s+([0-9]{1,2}\s+[A-Za-z]{3}\s+\d{4})\s*-\s*([0-9]{1,2}\s+[A-Za-z]{3}\s+\d{4})", re.I),
 
-    # Domeinnaam – tekst kan vol staan met puntjes/spaties tussen letters
-    # Voorbeeld: "D.o..m..a..i.n. .n.a..m..e........d..e.r.g..a.t.s..je..v...b.e..."
-    # We match de label losjes en herstellen vervolgens de domeinnaam.
+    # Domeinnaam – regel direct na klantnaam in het "Bill to" blok
     "domain": re.compile(
-        r"D[.\s]*o[.\s]*m[.\s]*a[.\s]*i[.\s]*n[.\s]*"
-        r"n[.\s]*a[.\s]*m[.\s]*e[.:\s]*([A-Za-z0-9.\s]+)",
+        r"Bill\s+to\s*\n[^\n]+\n([A-Za-z0-9.-]+\.[A-Za-z]{2,})",
         re.I,
     ),
 
@@ -84,10 +81,7 @@ def extract_invoice(pdf_path: str) -> dict:
 
     m = PATTERNS["domain"].search(text)
     if m:
-        candidate = re.sub(r"[\s.]", "", m.group(1))
-        m_dom = re.match(r"([A-Za-z0-9-]+)([A-Za-z]{2,})$", candidate)
-        if m_dom:
-            data["domain"] = f"{m_dom.group(1)}.{m_dom.group(2)}"
+        data["domain"] = m.group(1).strip().lower()
 
     totals = PATTERNS["total_eur"].findall(text)
     if totals:


### PR DESCRIPTION
## Summary
- parse the domain name from the 'Bill to' block instead of the detailed section

## Testing
- `python -m py_compile parse_invoices.py`
- `python parse_invoices.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68a61e5ff9b4832dad052d71b0f921a3