### PR TITLE
Add CSV invoice parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 This open-source tool automatically extracts details from **Google PDF invoices** and exports them to **CSV** for easy bookkeeping and accounting.
 
-The repository demonstrates two complementary approaches:
+The repository demonstrates several complementary approaches:
 
 - `ai_invoice_extract.py` – parses invoices with OpenAI’s `gpt-4o-mini` using a strict JSON schema.
 - `parse_invoices.py` – a ~10× faster option powered purely by regular expressions. It avoids generic AI and extra dependencies, showing that similar tasks can often be solved with straightforward rules.
+- `parse_csv_invoices.py` – reads Google invoice exports in CSV format and extracts the same key fields without any PDF processing.
 
 ## ✨ Features
 - 🔍 Extracts key fields:
@@ -40,6 +41,7 @@ pip install -r requirements.txt
 
 cp .env.example .env       # add your OpenAI API key as OPENAI_API_KEY_PARSER
 python ai_invoice_extract.py -i "invoices/*.pdf" -o output/invoices.csv
+python parse_csv_invoices.py -i "invoices/*.csv" -o output/csv_invoices.csv
 
 ```
 

--- a/parse_csv_invoices.py
+++ b/parse_csv_invoices.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Parse key invoice fields from CSV invoices.
+
+This utility scans CSV files that follow the Google invoice export format
+and extracts a limited set of fields for bookkeeping.
+"""
+
+import argparse
+import csv
+import glob
+import sys
+from pathlib import Path
+
+
+def extract_invoice(csv_path: str) -> dict:
+    """Extract invoice data from a CSV file."""
+    data = {
+        "file": str(csv_path),
+        "invoice_number": None,
+        "invoice_date": None,
+        "billing_id": None,
+        "invoice_amount": None,
+        "domain": None,
+        "error": None,
+    }
+
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            section = "meta"
+            header = None
+            for row in reader:
+                # switch section at empty line
+                if not row or all(not c.strip() for c in row):
+                    section = "items"
+                    header = None
+                    continue
+
+                if section == "meta":
+                    key = row[0].strip().lower()
+                    value = row[1].strip() if len(row) > 1 else ""
+                    if key == "invoice number":
+                        data["invoice_number"] = value
+                    elif key == "invoice date":
+                        data["invoice_date"] = value
+                    elif key == "billing id":
+                        data["billing_id"] = value
+                    elif key == "invoice amount":
+                        data["invoice_amount"] = value
+                else:
+                    if header is None:
+                        header = row  # skip header row
+                        continue
+                    # first non-empty domain name
+                    if row[0].strip():
+                        data["domain"] = row[0].strip()
+                        break
+    except Exception as e:  # pragma: no cover
+        data["error"] = f"parse_error: {e}"
+
+    return data
+
+
+def discover_csvs(input_path: Path, recursive: bool) -> list[Path]:
+    if input_path.is_file() and input_path.suffix.lower() == ".csv":
+        return [input_path]
+    pattern = "**/*.csv" if recursive else "*.csv"
+    return [Path(p) for p in glob.glob(str(input_path / pattern), recursive=recursive)]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Parse invoice fields from CSV invoices"
+    )
+    ap.add_argument(
+        "-i", "--input", required=True,
+        help="Path to CSV file or directory",
+    )
+    ap.add_argument(
+        "-o", "--out", default="csv_invoices_index.csv",
+        help="Output CSV (default: csv_invoices_index.csv)",
+    )
+    ap.add_argument(
+        "-r", "--recursive", action="store_true",
+        help="Recursively search subdirectories",
+    )
+    args = ap.parse_args()
+
+    input_path = Path(args.input).expanduser().resolve()
+    csvs = discover_csvs(input_path, args.recursive)
+
+    if not csvs:
+        print(f"Geen CSV's gevonden in: {input_path}", file=sys.stderr)
+        sys.exit(2)
+
+    rows = [extract_invoice(str(p)) for p in csvs]
+
+    fieldnames = [
+        "file",
+        "invoice_number",
+        "invoice_date",
+        "billing_id",
+        "invoice_amount",
+        "domain",
+        "error",
+    ]
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+
+    ok = sum(1 for r in rows if not r.get("error"))
+    print(f"Geschreven: {args.out}  |  {ok}/{len(rows)} records zonder fouten")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `parse_csv_invoices.py` to extract key fields from invoice CSV exports
- document CSV parsing workflow in README

## Testing
- `python -m py_compile parse_csv_invoices.py && python parse_csv_invoices.py -h`
- `python parse_csv_invoices.py -i sample_invoice.csv`
- `cat csv_invoices_index.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a62c0de144832da11f9044892f28db