### PR TITLE
Handle Dutch field names in CSV invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The repository demonstrates several complementary approaches:
 
 - `ai_invoice_extract.py` – parses invoices with OpenAI’s `gpt-4o-mini` using a strict JSON schema.
 - `parse_invoices.py` – a ~10× faster option powered purely by regular expressions. It avoids generic AI and extra dependencies, showing that similar tasks can often be solved with straightforward rules.
-- `parse_csv_invoices.py` – reads Google invoice exports in CSV format and extracts the same key fields without any PDF processing.
+- `parse_csv_invoices.py` – reads Google invoice exports in CSV format and extracts the same key fields without any PDF processing. Recognizes both English and Dutch field names.
 
 ## ✨ Features
 - 🔍 Extracts key fields:

--- a/parse_csv_invoices.py
+++ b/parse_csv_invoices.py
@@ -13,6 +13,19 @@ import sys
 from pathlib import Path
 
 
+# Supported meta field names in multiple languages
+KEY_MAP = {
+    "invoice number": "invoice_number",
+    "factuurnummer": "invoice_number",
+    "invoice date": "invoice_date",
+    "factuurdatum": "invoice_date",
+    "billing id": "billing_id",
+    "facturerings id": "billing_id",
+    "invoice amount": "invoice_amount",
+    "factuurbedrag": "invoice_amount",
+}
+
+
 def extract_invoice(csv_path: str) -> dict:
     """Extract invoice data from a CSV file."""
     data = {
@@ -38,16 +51,11 @@ def extract_invoice(csv_path: str) -> dict:
                     continue
 
                 if section == "meta":
-                    key = row[0].strip().lower()
+                    key = row[0].strip().lower().replace(":", "").replace("-", " ")
                     value = row[1].strip() if len(row) > 1 else ""
-                    if key == "invoice number":
-                        data["invoice_number"] = value
-                    elif key == "invoice date":
-                        data["invoice_date"] = value
-                    elif key == "billing id":
-                        data["billing_id"] = value
-                    elif key == "invoice amount":
-                        data["invoice_amount"] = value
+                    field = KEY_MAP.get(key)
+                    if field:
+                        data[field] = value
                 else:
                     if header is None:
                         header = row  # skip header row


### PR DESCRIPTION
## Summary
- support Dutch equivalents of invoice metadata in `parse_csv_invoices.py`
- document that the CSV parser now recognises both English and Dutch field names

## Testing
- `python parse_csv_invoices.py -i sample_dutch.csv -o out_dutch.csv`
- `python parse_csv_invoices.py -i sample_en.csv -o out_en.csv`

------
https://chatgpt.com/codex/tasks/task_e_68a7365c4420832db7d7c9ec47ae1d24